### PR TITLE
Firefox Build

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div id="hexCorpTabMenu">
-      <img src="icon_128.png" id="hexCorpLogo" />
+      <img src="icon_128.png" id="hexCorpLogo" /><br />
       <button id="off">Off</button><br />
       <button id="slow">Slow</button><br />
       <button id="medium">Medium</button><br />

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
     "husky": "^4.2.5",
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1"
+  },
+  "scripts": {
+    "firefox-build": "zip -r -FS ../HexCorpExtension.xpi * --exclude '*.git*' 'package*' '*node_modules*'",
+    "chrome-build": "zip -r -FS ../HexCorpExtension.zip * --exclude '*.git*' 'package*' '*node_modules*'"
   }
 }


### PR DESCRIPTION
The current extension could be easily converted into a Firefox Extension. Helpful for drones who want to use Firefox when browsing their favourite sites.

## Changes

A few changes had to be made for this:
* A single line break was required in the popup so that the popup looked the same as it does on chrome. 
* A command had been added to wrap up the extension into a `.xpi`. In all likelihood, this is probably unnecessary as the Firefox extension upload process probably accepts `.zip` files by now (`.xpi` files are essentially zip files anyway). However, I've stuck to it this way because of old habits.
* A command to create a chrome extension `.zip` was made as well, just because I could and because it felt odd to have one for firefox and not have one for the initial browser this extension was made for.

## Usage

In order to use the command to build the extension use the following:
```bash
npm run firefox-build
# or use `npm run chrome-build` if you want the chrome version
```
This will create `HexCorpExtension.xpi` (or `HexCorpExtension.zip`) in the directory above the project directory.

## Testing this out

Naturally, you'd want to test this out before submitting it to the [Firefox Developer Hub](https://addons.mozilla.org/en-US/developers/addons) so here's a way to do so:

1. You'll need to go into the extensions section, either by going through the menu or just typing `about:addons` in the Firefox browser.
2. Click the tools icon in the top right corner and select `Debug Add-ons` (do not select `Install Add-on From File` as the extension is not properly signed. For now you're installing it temporarily)
3. (If by any chance the option for `Debug Add-ons` isn't there, you can access debugging by typing `about:debugging` in the Firefox browser (I should have started with that to be honest))
4. Click `Load Temporary Addon` and select your `.xpi` or `.zip` from the file menu.
5. You can now play around with the extension.

You may notice that you don't even need to package the extension before loading it in. You can just as easily load the `manifest.json` and it'll load the unpackaged extension into the browser, which can be useful to test your extension while you're currently working on it.

~~(I realise that I may be pointing out things that you may already know or are fairly obvious. Apologies if so. I wanted to make sure I was being thorough when explaining how this extension could be converted to a Firefox extension.)~~